### PR TITLE
Loosen torelance of tests for EmbedAtomID

### DIFF
--- a/tests/links_tests/test_embed_atom_id.py
+++ b/tests/links_tests/test_embed_atom_id.py
@@ -49,12 +49,13 @@ def test_forward_gpu(model, data):
 
 def test_backward_cpu(model, data):
     x_data, y_grad = data
-    gradient_check.check_backward(model, x_data, y_grad, model.W)
+    gradient_check.check_backward(model, x_data, y_grad, model.W,
+                                  atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.gpu
 def test_backward_gpu(model, data):
     x_data, y_grad = [cuda.to_gpu(d) for d in data]
     model.to_gpu()
-    gradient_check.check_backward(model, x_data, y_grad, model.W)
-        
+    gradient_check.check_backward(model, x_data, y_grad, model.W,
+                                  atol=1e-3, rtol=1e-3)


### PR DESCRIPTION
Some times it fails because of numerical errors.