### PR TITLE
Test Python 3.5 and Chainer v2, v4pre in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ install:
   - source activate test-environment
   - conda install pip pytest
   - conda install -c rdkit rdkit
-  - if [ "${CHAINER_VERSION}" = "prerelease" ]; then
-      pip install --pre chainer
-    else
-      pip install "${CHAINER_VERSION}"
-    fi
+  - if [ "${CHAINER_VERSION}" = "prerelease" ]; then;
+      pip install --pre chainer;
+    else;
+      pip install "${CHAINER_VERSION}";
+    fi;
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ dist: trusty
 python:
   - 2.7
   - 3.6
+env
+  - CHAINER_VERSION="chainer<3"
+  - CHAINER_VERSION="chainer"
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -19,6 +22,7 @@ install:
   - source activate test-environment
   - conda install pip pytest
   - conda install -c rdkit rdkit
+  - pip install '${CHAINER_VERSION}'
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 python:
   - 2.7
   - 3.6
-env
+env:
   - CHAINER_VERSION="chainer<3"
   - CHAINER_VERSION="chainer"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - source activate test-environment
   - conda install pip pytest
   - conda install -c rdkit rdkit
-  - if [[ "${CHAINER_VERSION}" == "prerelease" ]]; then
+  - if [[ "${CHAINER_VERSION}" = "prerelease" ]]; then
   -   pip install --pre chainer
   - else
   -   pip install "${CHAINER_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ install:
   - source activate test-environment
   - conda install pip pytest
   - conda install -c rdkit rdkit
-  - if [[ "${CHAINER_VERSION}" = "prerelease" ]]; then
-  -   pip install --pre chainer
-  - else
-  -   pip install "${CHAINER_VERSION}"
-  - fi
+  - if [ "${CHAINER_VERSION}" = "prerelease" ]; then
+      pip install --pre chainer
+    else
+      pip install "${CHAINER_VERSION}"
+    fi
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda install -c rdkit rdkit
   - if [ "${CHAINER_VERSION}" = "prerelease" ]; then
       pip install --pre chainer;
-    else;
+    else
       pip install "${CHAINER_VERSION}";
     fi
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os: linux
 dist: trusty
 python:
   - 2.7
+  - 3.5
   - 3.6
 env:
   - CHAINER_VERSION="chainer<3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 env:
   - CHAINER_VERSION="chainer<3"
   - CHAINER_VERSION="chainer"
+  - CHAINER_VERSION="prerelease"
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -23,7 +24,11 @@ install:
   - source activate test-environment
   - conda install pip pytest
   - conda install -c rdkit rdkit
-  - pip install '${CHAINER_VERSION}'
+  - if [[ "${CHAINER_VERSION}" == "prerelease" ]]; then
+  -   pip install --pre chainer
+  - else
+  -   pip install "${CHAINER_VERSION}"
+  - fi
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ install:
   - source activate test-environment
   - conda install pip pytest
   - conda install -c rdkit rdkit
-  - if [ "${CHAINER_VERSION}" = "prerelease" ]; then;
+  - if [ "${CHAINER_VERSION}" = "prerelease" ]; then
       pip install --pre chainer;
     else;
       pip install "${CHAINER_VERSION}";
-    fi;
+    fi
   - python setup.py install
 
 script:


### PR DESCRIPTION
This PR changes `.travis.yml` to test if Chainer Chemistry work with Chainer v2.