### PR TITLE
Fix readthedocs setting

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,6 @@
+name: chainerchem
+type: sphinx
+base: docs/source
+requirements_file: docs/source/requirements.txt
+python:
+  setup_py_install: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,3 +4,5 @@ base: docs/source
 requirements_file: docs/source/requirements.txt
 python:
   setup_py_install: true
+conda:
+  file: docs/source/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,4 @@
-name: chainerchem
+name: chainer-chemistry
 type: sphinx
 base: docs/source
 requirements_file: docs/source/requirements.txt

--- a/docs/source/environment.yml
+++ b/docs/source/environment.yml
@@ -1,0 +1,79 @@
+
+name: chainerchem
+channels: !!python/tuple
+- defaults
+dependencies:
+- bzip2=1.0.6=3
+- cairo=1.14.8=0
+- certifi=2016.2.28=py36_0
+- fontconfig=2.12.1=3
+- freetype=2.5.5=2
+- jbig=2.1=0
+- jpeg=9b=0
+- libiconv=1.14=0
+- libpng=1.6.30=1
+- libtiff=4.0.6=3
+- libxml2=2.9.4=0
+- mkl=2017.0.3=0
+- numpy=1.13.1=py36_0
+- olefile=0.44=py36_0
+- openssl=1.0.2l=0
+- pandas=0.20.3=py36_0
+- pillow=4.2.1=py36_0
+- pip=9.0.1=py36_1
+- pixman=0.34.0=0
+- python=3.6.2=0
+- python-dateutil=2.6.1=py36_0
+- pytz=2017.2=py36_0
+- rdkit::boost=1.63.0=py36_1
+- rdkit::rdkit=2017.09.1=py36_1
+- readline=6.2=2
+- setuptools=36.4.0=py36_1
+- six=1.10.0=py36_0
+- sqlite=3.13.0=0
+- tk=8.5.18=0
+- wheel=0.29.0=py36_0
+- xz=5.2.3=0
+- zlib=1.2.11=0
+- pip:
+  - alabaster==0.7.10
+  - argh==0.26.2
+  - babel==2.5.1
+  - chainer==3.1.0
+  - chardet==3.0.4
+  - cupy==2.1.0.1
+  - decorator==4.1.2
+  - docutils==0.14
+  - fastrlock==0.3
+  - filelock==2.0.13
+  - idna==2.6
+  - imagesize==0.7.1
+  - ipython==6.2.1
+  - ipython-genutils==0.2.0
+  - jedi==0.11.0
+  - jinja2==2.10
+  - livereload==2.5.1
+  - markupsafe==1.0
+  - parso==0.1.0
+  - pathtools==0.1.2
+  - pexpect==4.3.0
+  - pickleshare==0.7.4
+  - port-for==0.3.1
+  - prompt-toolkit==1.0.15
+  - protobuf==3.5.0.post1
+  - ptyprocess==0.5.2
+  - pygments==2.2.0
+  - pyyaml==3.12
+  - requests==2.18.4
+  - simplegeneric==0.8.1
+  - snowballstemmer==1.2.1
+  - sphinx==1.6.5
+  - sphinx-autobuild==0.7.1
+  - sphinx-rtd-theme==0.2.4
+  - sphinxcontrib-websupport==1.0.1
+  - tornado==4.5.2
+  - tqdm==4.19.4
+  - traitlets==4.3.2
+  - urllib3==1.22
+  - watchdog==0.8.3
+  - wcwidth==0.1.7

--- a/docs/source/environment.yml
+++ b/docs/source/environment.yml
@@ -1,5 +1,5 @@
 
-name: chainerchem
+name: chainer-chemistry
 channels: !!python/tuple
 - defaults
 dependencies:

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,3 @@
+chainer
+pandas
+tqdm


### PR DESCRIPTION
Fix #48 
To generate documents properly, we need installing RDKit.
So I wrote some settings for installing RDKit in readthedocs environment.
The result is [here](http://chainer-chemistry-test.readthedocs.io/en/fixdocs/dataset.html)