### PR TITLE
Use --trainer-snapshot option of Tox21

### DIFF
--- a/examples/example_test_cpu.sh
+++ b/examples/example_test_cpu.sh
@@ -17,6 +17,8 @@ do
     if [ "${method}" !=  "schnet" ]
     then
     	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu}
+	snapshot=`ls ${out_dir}/snapshot_iter_*`  # Assume there is only one snapshot file.
+	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu} --trainer-snapshot ${snapshot}
     fi
 
     out_dir=all_${method}
@@ -24,6 +26,8 @@ do
     if [ "${method}" !=  "schnet" ]
     then
     	python inference_tox21.py --in-dir ${out_dir}
+	snapshot=`ls ${out_dir}/snapshot_iter_*`  # Assume there is only one snapshot file.
+	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu} --trainer-snapshot ${snapshot}
     fi
     cd ../
 

--- a/examples/example_test_cpu.sh
+++ b/examples/example_test_cpu.sh
@@ -17,7 +17,7 @@ do
     if [ "${method}" !=  "schnet" ]
     then
     	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu}
-	snapshot=`ls ${out_dir}/snapshot_iter_*`  # Assume there is only one snapshot file.
+	snapshot=`ls ${out_dir}/snapshot_iter_* | head -1`
 	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu} --trainer-snapshot ${snapshot}
     fi
 
@@ -26,7 +26,7 @@ do
     if [ "${method}" !=  "schnet" ]
     then
     	python inference_tox21.py --in-dir ${out_dir}
-	snapshot=`ls ${out_dir}/snapshot_iter_*`  # Assume there is only one snapshot file.
+	snapshot=`ls ${out_dir}/snapshot_iter_* | head -1`
 	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu} --trainer-snapshot ${snapshot}
     fi
     cd ../

--- a/examples/example_test_gpu.sh
+++ b/examples/example_test_gpu.sh
@@ -17,6 +17,8 @@ do
     if [ "${method}" !=  "schnet" ]
     then
     	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu}
+	snapshot=`ls ${out_dir}/snapshot_iter_*`  # Assume there is only one snapshot file.
+	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu} --trainer-snapshot ${snapshot}
     fi
 
     out_dir=all_${method}
@@ -24,6 +26,8 @@ do
     if [ "${method}" !=  "schnet" ]
     then
     	python inference_tox21.py --in-dir ${out_dir}
+	snapshot=`ls ${out_dir}/snapshot_iter_*`  # Assume there is only one snapshot file.
+	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu} --trainer-snapshot ${snapshot}
     fi
     cd ../
 

--- a/examples/example_test_gpu.sh
+++ b/examples/example_test_gpu.sh
@@ -17,7 +17,7 @@ do
     if [ "${method}" !=  "schnet" ]
     then
     	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu}
-	snapshot=`ls ${out_dir}/snapshot_iter_*`  # Assume there is only one snapshot file.
+	snapshot=`ls ${out_dir}/snapshot_iter_* | head -1`
 	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu} --trainer-snapshot ${snapshot}
     fi
 
@@ -26,7 +26,7 @@ do
     if [ "${method}" !=  "schnet" ]
     then
     	python inference_tox21.py --in-dir ${out_dir}
-	snapshot=`ls ${out_dir}/snapshot_iter_*`  # Assume there is only one snapshot file.
+	snapshot=`ls ${out_dir}/snapshot_iter_* | head -1`
 	python inference_tox21.py --in-dir ${out_dir} --gpu ${gpu} --trainer-snapshot ${snapshot}
     fi
     cd ../

--- a/examples/tox21/inference_tox21.py
+++ b/examples/tox21/inference_tox21.py
@@ -80,9 +80,12 @@ def main():
     X_test = D.NumpyTupleDataset(*test[:-1])
     y_test = test[-1]
 
+    # Load pretrained model
     predictor_ = predictor.build_predictor(
         method, config['unit_num'], config['conv_layers'], class_num)
-    snapshot_file = _find_latest_snapshot(args.in_dir)
+    snapshot_file = args.trainer_snapshot
+    if not snapshot_file:
+        snapshot_file = _find_latest_snapshot(args.in_dir)
     print('Loading pretrained model parameters from {}'.format(snapshot_file))
     chainer.serializers.load_npz(snapshot_file,
                                  predictor_, 'updater/model:main/predictor/')
@@ -120,6 +123,7 @@ def main():
     prediction_result_file = 'prediction.npz'
     print('Save prediction result to {}'.format(prediction_result_file))
     numpy.savez_compressed(prediction_result_file, y_pred)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR fixes #67 by using a snapshot specified by `--trainer-snapshot` if it is not empty. I also change the testing scripts for examples to check this option.