### PR TITLE
Write dependency on sklearn to the README of the QM9 example

### DIFF
--- a/examples/qm9/README.md
+++ b/examples/qm9/README.md
@@ -2,6 +2,12 @@
 
 QM9 dataset regression
 
+## Dependency
+
+This example depends on the following package as well as Chainer Chemistry and its dependent packages:
+
+- [`scikit-learn`](http://scikit-learn.org/stable/)
+
 ## How to run the code
 
 ### Train the model with qm9 dataset


### PR DESCRIPTION
We write dependency on `scikit-learn` of the QM9 example explicitly to its README.