### PR TITLE
Include napoleon as an extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'sphinx.ext.autosummary']
+    'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon']
 
 autosummary_generate = True
 


### PR DESCRIPTION
This PR adds [napoleon](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/index.html#) to `conf.py`. It is a Sphinx extension that enables us to write documents following Google Python Style Guide. As some of our documents are written in this style, we need to include it.