### PR TITLE
return smiles as numpy array

### DIFF
--- a/chainer_chemistry/dataset/parsers/csv_file_parser.py
+++ b/chainer_chemistry/dataset/parsers/csv_file_parser.py
@@ -31,7 +31,8 @@ class CSVFileParser(BaseFileParser):
     def __init__(self, preprocessor,
                  labels=None,
                  smiles_col='smiles',
-                 postprocess_label=None, postprocess_fn=None):
+                 postprocess_label=None, postprocess_fn=None,
+                 logger=getLogger(__name__)):
         super(CSVFileParser, self).__init__(preprocessor)
         if isinstance(labels, str):
             labels = [labels, ]
@@ -40,6 +41,7 @@ class CSVFileParser(BaseFileParser):
         self.postprocess_label = postprocess_label
         self.postprocess_fn = postprocess_fn
         self.smiles = None
+        self.logger = logger
 
     def parse(self, filepath, retain_smiles=False):
         """parse csv file using `preprocessor`
@@ -55,7 +57,7 @@ class CSVFileParser(BaseFileParser):
         Returns: Dataset
 
         """
-        logger = getLogger(__name__)
+        logger = self.logger
         pp = self.preprocessor
         if retain_smiles:
             self.smiles = []  # Initialize
@@ -105,7 +107,6 @@ class CSVFileParser(BaseFileParser):
                     fail_count += 1
                     continue
                 except Exception as e:
-                    logger = getLogger(__name__)
                     logger.warning('parse(), type: {}, {}'
                                    .format(type(e).__name__, e.args))
                     logger.info(traceback.format_exc())
@@ -156,3 +157,16 @@ class CSVFileParser(BaseFileParser):
             if self.postprocess_fn is not None:
                 result = self.postprocess_fn(result)
             return NumpyTupleDataset(result)
+
+    def get_smiles(self):
+        """get smiles array
+        
+        Returns (numpy.ndarray): 1-d numpy array with dtype=object (string),
+            which is a vector of smiles for each example.
+
+        """
+        if self.smiles is None:
+            self.logger.warning('smiles is None, please execute parse method '
+                                'with retrain_smiles=True.')
+            return None
+        return numpy.array(self.smiles)

--- a/chainer_chemistry/dataset/parsers/sdf_file_parser.py
+++ b/chainer_chemistry/dataset/parsers/sdf_file_parser.py
@@ -21,12 +21,13 @@ class SDFFileParser(BaseFileParser):
     """
 
     def __init__(self, preprocessor, labels=None, postprocess_label=None,
-                 postprocess_fn=None):
+                 postprocess_fn=None, logger=getLogger(__name__)):
         super(SDFFileParser, self).__init__(preprocessor)
         self.labels = labels
         self.postprocess_label = postprocess_label
         self.postprocess_fn = postprocess_fn
         self.smiles = None
+        self.logger = logger
 
     def parse(self, filepath, retain_smiles=False):
         """parse sdf file using `preprocessor`
@@ -41,7 +42,7 @@ class SDFFileParser(BaseFileParser):
         Returns: Dataset
 
         """
-        logger = getLogger(__name__)
+        logger = self.logger
         pp = self.preprocessor
         if retain_smiles:
             self.smiles = []  # Initialize
@@ -96,7 +97,6 @@ class SDFFileParser(BaseFileParser):
                     fail_count += 1
                     continue
                 except Exception as e:
-                    logger = getLogger(__name__)
                     logger.warning('parse() error, type: {}, {}'
                                    .format(type(e).__name__, e.args))
                     continue
@@ -137,3 +137,16 @@ class SDFFileParser(BaseFileParser):
             if self.postprocess_fn is not None:
                 result = self.postprocess_fn(result)
             return NumpyTupleDataset(result)
+
+    def get_smiles(self):
+        """get smiles array
+
+        Returns (numpy.ndarray): 1-d numpy array with dtype=object (string),
+            which is a vector of smiles for each example.
+
+        """
+        if self.smiles is None:
+            self.logger.warning('smiles is None, please execute parse method '
+                                'with retrain_smiles=True.')
+            return None
+        return numpy.array(self.smiles)

--- a/chainer_chemistry/datasets/qm9.py
+++ b/chainer_chemistry/datasets/qm9.py
@@ -36,7 +36,7 @@ def get_qm9(preprocessor=None, labels=None, retain_smiles=False):
             If it is None, default `AtomicNumberPreprocessor` is used.
         labels (str or list): List of target labels.
         retain_smiles (bool): If set to ``True``,
-            smiles list is also returned.
+            smiles array is also returned.
 
     Returns:
         dataset, which is composed of `features`, which depends on
@@ -57,7 +57,7 @@ def get_qm9(preprocessor=None, labels=None, retain_smiles=False):
                            labels=labels, smiles_col='SMILES1')
     dataset = parser.parse(get_qm9_filepath(), retain_smiles=retain_smiles)
     if retain_smiles:
-        return dataset, parser.smiles
+        return dataset, parser.get_smiles()
     else:
         return dataset
 

--- a/chainer_chemistry/datasets/tox21.py
+++ b/chainer_chemistry/datasets/tox21.py
@@ -48,7 +48,7 @@ def get_tox21(preprocessor=None, labels=None, retain_smiles=False):
             This should be chosen based on the network to be trained.
             If it is None, default `AtomicNumberPreprocessor` is used.
         labels (str or list): List of target labels.
-        retain_smiles (bool): If set to True, smiles list is also returned.
+        retain_smiles (bool): If set to True, smiles array is also returned.
 
     Returns:
         The 3-tuple consisting of train, validation and test
@@ -74,11 +74,11 @@ def get_tox21(preprocessor=None, labels=None, retain_smiles=False):
 
     if retain_smiles:
         train = parser.parse(get_tox21_filepath('train'), retain_smiles=True)
-        train_smiles = parser.smiles
+        train_smiles = parser.get_smiles()
         val = parser.parse(get_tox21_filepath('val'), retain_smiles=True)
-        val_smiles = parser.smiles
+        val_smiles = parser.get_smiles()
         test = parser.parse(get_tox21_filepath('test'), retain_smiles=True)
-        test_smiles = parser.smiles
+        test_smiles = parser.get_smiles()
         return train, val, test, train_smiles, val_smiles, test_smiles
     else:
         train = parser.parse(get_tox21_filepath('train'))

--- a/tests/dataset_tests/parsers_tests/test_sdf_file_parser.py
+++ b/tests/dataset_tests/parsers_tests/test_sdf_file_parser.py
@@ -46,9 +46,31 @@ def test_sdf_file_parser(sdf_file, mols):
     check_input_features(dataset[1], expect)
 
 
+def test_sdf_file_parser_retain_smiles(sdf_file, mols):
+    preprocessor = NFPPreprocessor()
+    parser = SDFFileParser(preprocessor)
+    dataset = parser.parse(sdf_file, retain_smiles=True)
+    smiles = parser.get_smiles()
+    assert len(dataset) == 2
+
+    # As we want test SDFFileParser, we assume
+    # NFPPreprocessor works as documented.
+    expect = preprocessor.get_input_features(mols[0])
+    check_input_features(dataset[0], expect)
+
+    expect = preprocessor.get_input_features(mols[1])
+    check_input_features(dataset[1], expect)
+
+    # check smiles array
+    assert type(smiles) == numpy.ndarray
+    assert smiles.ndim == 1
+    assert len(smiles) == len(dataset)
+    assert smiles[0] == 'CN=C=O'
+    assert smiles[1] == 'Cc1ccccc1'
+
 # TODO(oono)
 # test with non-default options of SDFFileParser
 
 
 if __name__ == '__main__':
-    pytest.main()
+    pytest.main([__file__, '-s', '-v'])


### PR DESCRIPTION
Originally smiles is returned as `list` with `get_qm9` or `get_tox21` method.

However this PR is to change its type to return `numpy array`.

The motivation is that since dataset features are of numpy array, I felt it is more unified when numpy array is returned.
Also, advanced indexing can be used when the type is numpy array instead of `list`

However since `list` type was originally returned, **this PR breaks backward compatibility** while I guess the effect is small (because there is no example code to use `retain_smiles=True` for now.