### PR TITLE
Fix some dependencies for rtd

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,6 +3,6 @@ type: sphinx
 base: docs/source
 requirements_file: docs/source/requirements.txt
 python:
-  setup_py_install: true
+  pip_install: true
 conda:
   file: docs/source/environment.yml

--- a/docs/source/environment.yml
+++ b/docs/source/environment.yml
@@ -39,9 +39,7 @@ dependencies:
   - alabaster==0.7.10
   - argh==0.26.2
   - babel==2.5.1
-  - chainer==3.1.0
   - chardet==3.0.4
-  - cupy==2.1.0.1
   - decorator==4.1.2
   - docutils==0.14
   - fastrlock==0.3

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,3 +1,5 @@
 chainer
+scipy
+scikit-learn
 pandas
 tqdm


### PR DESCRIPTION
This pull request solves build failure of readthedocs.
It is caused by cupy build error in RTD environment and dependency on scikit-learn. Scikit-learn depends on Scipy. 