### PR TITLE
Add scipy in dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ install_requires = [
     'chainer>=2.0',
     'pandas',
     'scikit-learn',
+    'scipy',
     'tqdm',
 ]
 


### PR DESCRIPTION
Issue: https://github.com/pfnet-research/chainer-chemistry/issues/82

scikit-learn does not install scipy automatically, so we explicitly include scipy as dependency.