### PR TITLE
Print warning message when import error occured at chainer_chemistry.…

### DIFF
--- a/chainer_chemistry/__init__.py
+++ b/chainer_chemistry/__init__.py
@@ -1,5 +1,15 @@
+import warnings
+
 from chainer_chemistry import dataset  # NOQA
-from chainer_chemistry import datasets  # NOQA
+try:
+    from chainer_chemistry import datasets  # NOQA
+except ImportError:
+    warnings.warn(
+        'A module chainer_chemistry.datasets was not imported, '
+        'probably because RDKit is not installed. '
+        'To install RDKit, please follow instruction in '
+        'https://github.com/pfnet-research/chainer-chemistry#installation.',
+        UserWarning)
 from chainer_chemistry import functions  # NOQA
 from chainer_chemistry import links  # NOQA
 from chainer_chemistry import models  # NOQA


### PR DESCRIPTION
…datasets to handle a situation when RDKit is not installed

This pull request is intended to solve issue #119.
If RDKit is installed, everything goes as usual.
If not installed,
- A warning message will be shown when we do "import chainer_chemistry". A module chainer_chemistry.datasets will simply be ignored.
- Meanwhile, an error will invoke when we explicitly import chainer_chemistry.datasets.