### PR TITLE
Remove Chainer v2 test from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - 3.6
 env:
   - CHAINER_VERSION="chainer<3"
+  - CHAINER_VERSION="chainer<4"
   - CHAINER_VERSION="chainer"
   - CHAINER_VERSION="prerelease"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os: linux
 dist: trusty
 python:
   - 2.7
-  - 3.5
   - 3.6
 env:
   - CHAINER_VERSION="chainer<3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ os: linux
 dist: trusty
 python:
   - 2.7
+  - 3.5
   - 3.6
 env:
-  - CHAINER_VERSION="chainer<3"
-  - CHAINER_VERSION="chainer<4"
   - CHAINER_VERSION="chainer"
   - CHAINER_VERSION="prerelease"
 


### PR DESCRIPTION
Since Chainer v4 has been released, Chainer installed by `CHAINER_VERSION="chainer` in travis has been changed to from v4 to v3. That means Chainer v3 is not tested in the current configuration. This PR adds a test with Chainer v4 to `.travis.yml`.

I did not remove configuration about Chainer v2 (`CHAINER_VERSION="chainer<3`)  because testing time in Travis is not a bottleneck in the current workflow. But I would be like opinions.