### PR TITLE
Remove conditional import of Classifier

### DIFF
--- a/examples/qm9/predict_qm9.py
+++ b/examples/qm9/predict_qm9.py
@@ -21,14 +21,7 @@ from chainer import Variable
 import numpy  # NOQA
 
 from chainer_chemistry import datasets as D
-try:
-    from chainer_chemistry.models.prediction import Regressor
-except ImportError:
-    print('[ERROR] This example uses newly implemented `Regressor` class.\n'
-          'Please install the library from master branch.\n See '
-          'https://github.com/pfnet-research/chainer-chemistry#installation'
-          ' for detail.')
-    exit()
+from chainer_chemistry.models.prediction import Regressor
 from chainer_chemistry.dataset.converters import concat_mols
 from chainer_chemistry.dataset.preprocessors import preprocess_method_dict
 from chainer_chemistry.datasets import NumpyTupleDataset

--- a/examples/qm9/train_qm9.py
+++ b/examples/qm9/train_qm9.py
@@ -20,14 +20,7 @@ import numpy
 
 from chainer_chemistry import datasets as D
 from chainer_chemistry.models import MLP, NFP, GGNN, SchNet, WeaveNet, RSGCN  # NOQA
-try:
-    from chainer_chemistry.models.prediction import Regressor
-except ImportError:
-    print('[ERROR] This example uses newly implemented `Regressor` class.\n'
-          'Please install the library from master branch.\n See '
-          'https://github.com/pfnet-research/chainer-chemistry#installation'
-          ' for detail.')
-    exit()
+from chainer_chemistry.models.prediction import Regressor
 from chainer_chemistry.dataset.converters import concat_mols
 from chainer_chemistry.dataset.preprocessors import preprocess_method_dict
 from chainer_chemistry.datasets import NumpyTupleDataset

--- a/examples/tox21/predict_tox21_with_classifier.py
+++ b/examples/tox21/predict_tox21_with_classifier.py
@@ -12,14 +12,7 @@ from rdkit import RDLogger
 import six
 
 from chainer_chemistry.dataset.converters import concat_mols
-try:
-    from chainer_chemistry.models.prediction import Classifier
-except ImportError:
-    print('[ERROR] This example uses newly implemented `Classifier` class.\n'
-          'Please install the library from master branch.\n See '
-          'https://github.com/pfnet-research/chainer-chemistry#installation'
-          ' for detail.')
-    exit()
+from chainer_chemistry.models.prediction import Classifier
 from chainer_chemistry.training.extensions.roc_auc_evaluator import ROCAUCEvaluator  # NOQA
 
 import data

--- a/examples/tox21/train_tox21.py
+++ b/examples/tox21/train_tox21.py
@@ -20,14 +20,7 @@ from chainer_chemistry.dataset.converters import concat_mols
 from chainer_chemistry import datasets as D
 from chainer_chemistry.iterators.balanced_serial_iterator import BalancedSerialIterator  # NOQA
 from chainer_chemistry.training.extensions import ROCAUCEvaluator  # NOQA
-try:
-    from chainer_chemistry.models.prediction import Classifier
-except ImportError:
-    print('[ERROR] This example uses newly implemented `Classifier` class.\n'
-          'Please install the library from master branch.\n See '
-          'https://github.com/pfnet-research/chainer-chemistry#installation'
-          ' for detail.')
-    exit()
+from chainer_chemistry.models.prediction import Classifier
 
 import data
 import predictor


### PR DESCRIPTION
This PR changes the Tox21 and QM9 examples to skip availability of `Classifier`.

Currently, code in the Tox21 and QM9 examples check if `Classifier` is available because previously the version we can install via pip was v0.2.0, where `Classifier` is not available. Now we can get v0.3.0 with pip, we do not need this conditioning.