### PR TITLE
Rename duplicated test name

### DIFF
--- a/tests/datasets_tests/molnet_tests/test_molnet.py
+++ b/tests/datasets_tests/molnet_tests/test_molnet.py
@@ -111,7 +111,7 @@ def test_get_molnet_clearance_dataset():
 
 
 @pytest.mark.slow
-def test_get_molnet_clearance_dataset():
+def test_get_molnet_clearance_dataset_with_return_smiles_enabled():
     # test default behavior
     pp = AtomicNumberPreprocessor()
     datasets = molnet.get_molnet_dataset('clearance', preprocessor=pp,


### PR DESCRIPTION
There are two tests named`test_get_molnet_clearance_dataset` in a file. So, either of them is not tested. This PR renames one of them.