### PR TITLE
Construct discrete edge matrix fast

### DIFF
--- a/chainer_chemistry/dataset/preprocessors/common.py
+++ b/chainer_chemistry/dataset/preprocessors/common.py
@@ -162,26 +162,6 @@ def construct_discrete_edge_matrix(mol, out_size=-1):
         ch = bond_type_to_channel[bond_type]
         i = bond.GetBeginAtomIdx()
         j = bond.GetEndAtomIdx()
-        # print('{} {} {}'.format(i, j, bond_type))
         adjs[ch, i, j] = 1.0
         adjs[ch, j, i] = 1.0
-
-    adjs_test = numpy.zeros((4, size, size), dtype=numpy.float32)
-    for i in range(N):
-        for j in range(N):
-            bond = mol.GetBondBetweenAtoms(i, j)  # type: Chem.Bond
-            if bond is not None:
-                bond_type = str(bond.GetBondType())
-                if bond_type == 'SINGLE':
-                    adjs_test[0, i, j] = 1.0
-                elif bond_type == 'DOUBLE':
-                    adjs_test[1, i, j] = 1.0
-                elif bond_type == 'TRIPLE':
-                    adjs_test[2, i, j] = 1.0
-                elif bond_type == 'AROMATIC':
-                    adjs_test[3, i, j] = 1.0
-                else:
-                    raise ValueError("[ERROR] Unknown bond type {}"
-                                     .format(bond_type))
-    assert numpy.allclose(adjs, adjs_test)
     return adjs

--- a/chainer_chemistry/dataset/preprocessors/common.py
+++ b/chainer_chemistry/dataset/preprocessors/common.py
@@ -85,7 +85,9 @@ def construct_adj_matrix(mol, out_size=-1, self_connection=True):
             If True, diagonal element of adjacency matrix is filled with 1.
 
     Returns:
-        numpy.ndarray: the adjcent matrix of the input molecule.
+        adj_array (numpy.ndarray): The adjacent matrix of the input molecule.
+            It is 2-dimensional array with shape (atoms1, atoms2), where
+            atoms1 & atoms2 represent from and to of the edge respectively.
             If ``out_size`` is non-negative, the returned
             its size is equal to that value. Otherwise,
             it is equal to the number of atoms in the the molecule.
@@ -107,8 +109,60 @@ def construct_adj_matrix(mol, out_size=-1, self_connection=True):
                                 dtype=numpy.float32)
         adj_array[:s0, :s1] = adj
     else:
-        raise ValueError('`out_size` (={}) must be negative or '
-                         'larger than or equal to the number '
-                         'of atoms in the input molecules (={})'
-                         '.'.format(out_size, s0))
+        raise ValueError(
+            '`out_size` (={}) must be negative or larger than or equal to the '
+            'number of atoms in the input molecules (={}).'
+            .format(out_size, s0))
     return adj_array
+
+
+def construct_discrete_edge_matrix(mol, out_size=-1):
+    """Returns the edge-type dependent adjacency matrix of the given molecule.
+
+    Args:
+        mol (rdkit.Chem.Mol): Input molecule.
+        out_size (int): The size of the returned matrix.
+            If this option is negative, it does not take any effect.
+            Otherwise, it must be larger than the number of atoms
+            in the input molecules. In that case, the adjacent
+            matrix is expanded and zeros are padded to right
+            columns and bottom rows.
+
+    Returns:
+        adj_array (numpy.ndarray): The adjacent matrix of the input molecule.
+            It is 3-dimensional array with shape (edge_type, atoms1, atoms2),
+            where edge_type represents the bond type,
+            atoms1 & atoms2 represent from and to of the edge respectively.
+            If ``out_size`` is non-negative, its size is equal to that value.
+            Otherwise, it is equal to the number of atoms in the the molecule.
+    """
+    if mol is None:
+        raise MolFeatureExtractionError('mol is None')
+    N = mol.GetNumAtoms()
+
+    if out_size < 0:
+        size = N
+    elif out_size >= N:
+        size = out_size
+    else:
+        raise ValueError(
+            'out_size {} is smaller than number of atoms in mol {}'
+            .format(out_size, N))
+    adjs = numpy.zeros((4, size, size), dtype=numpy.float32)
+    for i in range(N):
+        for j in range(N):
+            bond = mol.GetBondBetweenAtoms(i, j)  # type: Chem.Bond
+            if bond is not None:
+                bond_type = str(bond.GetBondType())
+                if bond_type == 'SINGLE':
+                    adjs[0, i, j] = 1.0
+                elif bond_type == 'DOUBLE':
+                    adjs[1, i, j] = 1.0
+                elif bond_type == 'TRIPLE':
+                    adjs[2, i, j] = 1.0
+                elif bond_type == 'AROMATIC':
+                    adjs[3, i, j] = 1.0
+                else:
+                    raise ValueError("[ERROR] Unknown bond type {}"
+                                     .format(bond_type))
+    return adjs

--- a/chainer_chemistry/dataset/preprocessors/common.py
+++ b/chainer_chemistry/dataset/preprocessors/common.py
@@ -1,6 +1,7 @@
 """Common preprocess method is gethered in this file"""
 
 import numpy
+from rdkit import Chem
 from rdkit.Chem import rdmolops
 
 
@@ -149,20 +150,38 @@ def construct_discrete_edge_matrix(mol, out_size=-1):
             'out_size {} is smaller than number of atoms in mol {}'
             .format(out_size, N))
     adjs = numpy.zeros((4, size, size), dtype=numpy.float32)
+
+    bond_type_to_channel = {
+        Chem.BondType.SINGLE: 0,
+        Chem.BondType.DOUBLE: 1,
+        Chem.BondType.TRIPLE: 2,
+        Chem.BondType.AROMATIC: 3
+    }
+    for bond in mol.GetBonds():
+        bond_type = bond.GetBondType()
+        ch = bond_type_to_channel[bond_type]
+        i = bond.GetBeginAtomIdx()
+        j = bond.GetEndAtomIdx()
+        # print('{} {} {}'.format(i, j, bond_type))
+        adjs[ch, i, j] = 1.0
+        adjs[ch, j, i] = 1.0
+
+    adjs_test = numpy.zeros((4, size, size), dtype=numpy.float32)
     for i in range(N):
         for j in range(N):
             bond = mol.GetBondBetweenAtoms(i, j)  # type: Chem.Bond
             if bond is not None:
                 bond_type = str(bond.GetBondType())
                 if bond_type == 'SINGLE':
-                    adjs[0, i, j] = 1.0
+                    adjs_test[0, i, j] = 1.0
                 elif bond_type == 'DOUBLE':
-                    adjs[1, i, j] = 1.0
+                    adjs_test[1, i, j] = 1.0
                 elif bond_type == 'TRIPLE':
-                    adjs[2, i, j] = 1.0
+                    adjs_test[2, i, j] = 1.0
                 elif bond_type == 'AROMATIC':
-                    adjs[3, i, j] = 1.0
+                    adjs_test[3, i, j] = 1.0
                 else:
                     raise ValueError("[ERROR] Unknown bond type {}"
                                      .format(bond_type))
+    assert numpy.allclose(adjs, adjs_test)
     return adjs

--- a/chainer_chemistry/dataset/preprocessors/ggnn_preprocessor.py
+++ b/chainer_chemistry/dataset/preprocessors/ggnn_preprocessor.py
@@ -1,55 +1,8 @@
-import numpy
-
 from chainer_chemistry.dataset.preprocessors.common \
-    import construct_atomic_number_array
-from chainer_chemistry.dataset.preprocessors.common import MolFeatureExtractionError  # NOQA
+    import construct_atomic_number_array, construct_discrete_edge_matrix
 from chainer_chemistry.dataset.preprocessors.common import type_check_num_atoms
 from chainer_chemistry.dataset.preprocessors.mol_preprocessor \
     import MolPreprocessor
-
-
-def construct_discrete_edge_matrix(mol, out_size=-1):
-    """construct discrete edge matrix
-
-    Args:
-        mol (Chem.Mol):
-        out_size (int):
-
-    Returns (numpy.ndarray):
-
-    """
-
-    if mol is None:
-        raise MolFeatureExtractionError('mol is None')
-    N = mol.GetNumAtoms()
-
-    if out_size < 0:
-        size = N
-    elif out_size >= N:
-        size = out_size
-    else:
-        raise MolFeatureExtractionError('out_size {} is smaller than number '
-                                        'of atoms in mol {}'
-                                        .format(out_size, N))
-
-    adjs = numpy.zeros((4, size, size), dtype=numpy.float32)
-    for i in range(N):
-        for j in range(N):
-            bond = mol.GetBondBetweenAtoms(i, j)  # type: Chem.Bond
-            if bond is not None:
-                bond_type = str(bond.GetBondType())
-                if bond_type == 'SINGLE':
-                    adjs[0, i, j] = 1.0
-                elif bond_type == 'DOUBLE':
-                    adjs[1, i, j] = 1.0
-                elif bond_type == 'TRIPLE':
-                    adjs[2, i, j] = 1.0
-                elif bond_type == 'AROMATIC':
-                    adjs[3, i, j] = 1.0
-                else:
-                    raise ValueError("[ERROR] Unknown bond type {}"
-                                     .format(bond_type))
-    return adjs
 
 
 class GGNNPreprocessor(MolPreprocessor):

--- a/chainer_chemistry/utils/extend.py
+++ b/chainer_chemistry/utils/extend.py
@@ -45,7 +45,7 @@ def extend_adj(adj, out_size, axis=None, value=0):
         adj (numpy.ndarray): the array whose `axis` to be extended.
             first axis is considered as "batch" axis.
         out_size (int): target output size for specified `axis`.
-        axis (int or None): node feature axis to be extended. Default is None,
+        axis (list or None): node feature axis to be extended. Default is None,
             in this case `axis=[-1, -2]` is used to extend last 2 axes.
         value (int or float): value to be filled for extended place.
 


### PR DESCRIPTION
Please merge after https://github.com/pfnet-research/chainer-chemistry/pull/260


This PR construct discrete edge matrix in O(E), instead of O(N^2)

I checked the time difference in this kind of code
```
from rdkit import Chem
from chainer_chemistry.dataset.preprocessors import common

from contextlib import contextmanager
from time import time, perf_counter


@contextmanager
def timer(name):
    t0 = perf_counter()
    yield
    t1 = perf_counter()
    print('[{}] done in {:.6f} ms'.format(name, (t1-t0) * 1000))


num_atoms_list = [10, 100, 1000]
for num_atoms in num_atoms_list:
    mol = Chem.MolFromSmiles('C' * num_atoms)
    # mol = Chem.MolFromSmiles('CC=' * (num_atoms // 2) + 'C')
    with timer('num_atoms {}'.format(num_atoms)):
        common.construct_discrete_edge_matrix(mol)

```

Results:
- Before this PR
```
[num_atoms 10] done in 0.166040 ms
[num_atoms 100] done in 4.342746 ms
[num_atoms 1000] done in 440.205252 ms
```

- After this PR
```
[num_atoms 10] done in 0.356755 ms
[num_atoms 100] done in 0.550554 ms
[num_atoms 1000] done in 11.944093 ms
```
