### PR TITLE
Fix FutureWarning in permute_adj func

### DIFF
--- a/chainer_chemistry/utils/permutation.py
+++ b/chainer_chemistry/utils/permutation.py
@@ -62,5 +62,5 @@ def permute_adj(adj, permutation_index, axis=None):
             in_indices[axis[1]] = j
             out_indices[axis[0]] = permutation_index[i]
             out_indices[axis[1]] = permutation_index[j]
-            out_adj[in_indices] = adj[out_indices]
+            out_adj[tuple(in_indices)] = adj[tuple(out_indices)]
     return out_adj


### PR DESCRIPTION
Fix this warning.

```
FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
    out_adj[in_indices] = adj[tuple(out_indices)]
```
