### PR TITLE
bug fix: consider the case when metrics returns non-Variable case.

### DIFF
--- a/chainer_chemistry/models/prediction/classifier.py
+++ b/chainer_chemistry/models/prediction/classifier.py
@@ -6,7 +6,7 @@ import chainer
 from chainer.dataset.convert import concat_examples
 from chainer.functions.evaluation import accuracy
 from chainer.functions.loss import softmax_cross_entropy
-from chainer import cuda, Variable  #N OQA
+from chainer import cuda, Variable  # NOQA
 from chainer import reporter
 from chainer_chemistry.models.prediction.base import BaseForwardModel
 

--- a/chainer_chemistry/models/prediction/classifier.py
+++ b/chainer_chemistry/models/prediction/classifier.py
@@ -1,13 +1,14 @@
 import warnings
 
+import numpy
+
 import chainer
 from chainer.dataset.convert import concat_examples
 from chainer.functions.evaluation import accuracy
 from chainer.functions.loss import softmax_cross_entropy
-from chainer import cuda
+from chainer import cuda, Variable  #N OQA
 from chainer import reporter
 from chainer_chemistry.models.prediction.base import BaseForwardModel
-import numpy
 
 
 def _argmax(*args):
@@ -112,9 +113,11 @@ class Classifier(BaseForwardModel):
         self.initialize(device)
 
     def _convert_to_scalar(self, value):
-        """Converts an input value to a scalar if its type is a numpy or cupy
-        array, otherwise it returns the value as it is.
+        """Converts an input value to a scalar if its type is a Variable,
+        numpy or cupy array, otherwise it returns the value as it is.
         """
+        if isinstance(value, Variable):
+            value = value.array
         if numpy.isscalar(value):
             return value
         if type(value) is not numpy.array:
@@ -169,11 +172,11 @@ class Classifier(BaseForwardModel):
         self.y = self.predictor(*args, **kwargs)
         self.loss = self.lossfun(self.y, t)
         reporter.report(
-            {'loss': self._convert_to_scalar(self.loss.data)}, self)
+            {'loss': self._convert_to_scalar(self.loss)}, self)
         if self.compute_metrics:
             # Note: self.accuracy is `dict`, which is different from original
             # chainer implementation
-            self.metrics = {key: self._convert_to_scalar(value(self.y, t).data)
+            self.metrics = {key: self._convert_to_scalar(value(self.y, t))
                             for key, value in self.metrics_fun.items()}
             reporter.report(self.metrics, self)
         return self.loss


### PR DESCRIPTION
resolves https://github.com/pfnet-research/chainer-chemistry/issues/289

Metrics function can return normal array instead of Variable, so `self._convert_to_scalar(value(self.y, t).data` is not ok (when the returned value is array, `.data` refer memoryview instead of actual value).
