### PR TITLE
NFP input size invariant: add is_real_node argument

### DIFF
--- a/chainer_chemistry/links/readout/nfp_readout.py
+++ b/chainer_chemistry/links/readout/nfp_readout.py
@@ -21,11 +21,17 @@ class NFPReadout(chainer.Chain):
         self.in_channels = in_channels
         self.out_size = out_size
 
-    def __call__(self, h):
+    def __call__(self, h, is_real_node=None):
         # h: (minibatch, atom, ch)
+        # input  is_real_node shape (minibatch, num_nodes)
 
         # ---Readout part ---
         i = self.output_weight(h)
         i = functions.softmax(i, axis=2)  # softmax along channel axis
+        if is_real_node is not None:
+            # mask virtual node feature to be 0
+            mask = self.xp.broadcast_to(
+                is_real_node[:, :, None], i.shape)
+            i = i * mask
         i = functions.sum(i, axis=1)  # sum along atom's axis
         return i

--- a/chainer_chemistry/links/readout/nfp_readout.py
+++ b/chainer_chemistry/links/readout/nfp_readout.py
@@ -22,8 +22,8 @@ class NFPReadout(chainer.Chain):
         self.out_size = out_size
 
     def __call__(self, h, is_real_node=None):
-        # h: (minibatch, atom, ch)
-        # input  is_real_node shape (minibatch, num_nodes)
+        # h: (minibatch, node, ch)
+        # is_real_node: (minibatch, node)
 
         # ---Readout part ---
         i = self.output_weight(h)

--- a/chainer_chemistry/links/readout/nfp_readout.py
+++ b/chainer_chemistry/links/readout/nfp_readout.py
@@ -1,7 +1,7 @@
 import chainer
 from chainer import functions
 
-from chainer_chemistry.links import GraphLinear
+from chainer_chemistry.links.connection.graph_linear import GraphLinear
 
 
 class NFPReadout(chainer.Chain):

--- a/chainer_chemistry/links/update/nfp_update.py
+++ b/chainer_chemistry/links/update/nfp_update.py
@@ -3,7 +3,7 @@ from chainer import functions
 import numpy
 
 import chainer_chemistry
-from chainer_chemistry.links import GraphLinear
+from chainer_chemistry.links.connection.graph_linear import GraphLinear
 
 
 class NFPUpdate(chainer.Chain):

--- a/chainer_chemistry/models/nfp.py
+++ b/chainer_chemistry/models/nfp.py
@@ -15,9 +15,7 @@ class NFP(chainer.Chain):
     See: David K Duvenaud, Dougal Maclaurin, Jorge Iparraguirre, Rafael
         Bombarell, Timothy Hirzel, Alan Aspuru-Guzik, and Ryan P Adams (2015).
         Convolutional networks on graphs for learning molecular fingerprints.
-        In C. Cortes, N. D. Lawrence, D. D. Lee, M. Sugiyama, and R. Garnett,
-        editors, *Advances in Neural Information Processing Systems (NIPS) 28*,
-        pages 2224–2232. Curran Asso- ciates, Inc.
+        *Advances in Neural Information Processing Systems (NIPS) 28*,
 
     Args:
         out_dim (int): dimension of output feature vector

--- a/chainer_chemistry/models/nfp.py
+++ b/chainer_chemistry/models/nfp.py
@@ -62,8 +62,9 @@ class NFP(chainer.Chain):
             adj (numpy.ndarray): minibatch of adjancency matrix
                 `adj[mol_index]` represents `mol_index`-th molecule's
                 adjacency matrix
-            is_real_node (numpy.ndarray): (minibatch, num_nodes), 1 for real
-               node, 0 for virtual node.
+            is_real_node (numpy.ndarray): 2-dim array (minibatch, num_nodes).
+                1 for real node, 0 for virtual node.
+                If `None`, all node is considered as real node.
 
         Returns:
             ~chainer.Variable: minibatch of fingerprint

--- a/tests/models_tests/test_nfp.py
+++ b/tests/models_tests/test_nfp.py
@@ -5,6 +5,7 @@ import pytest
 
 from chainer_chemistry.config import MAX_ATOMIC_NUM
 from chainer_chemistry.models.nfp import NFP
+from chainer_chemistry.utils.extend import extend_adj, extend_node
 from chainer_chemistry.utils.permutation import permute_adj
 from chainer_chemistry.utils.permutation import permute_node
 
@@ -77,5 +78,20 @@ def test_forward_cpu_graph_invariant(model, data):
     assert numpy.allclose(y_actual, permute_y_actual, rtol=1e-5, atol=1e-6)
 
 
+def test_forward_cpu_input_size_invariant(model, data):
+    atom_data, adj_data = data[0], data[1]
+    is_real_node = numpy.ones(atom_data.shape, dtype=numpy.float32)
+    y_actual = cuda.to_cpu(model(atom_data, adj_data, is_real_node).data)
+
+    atom_data_ex = extend_node(atom_data, out_size=8)
+    adj_data_ex = extend_adj(adj_data, out_size=8)
+    is_real_node_ex = extend_node(is_real_node, out_size=8)
+    print('size', atom_data.shape, adj_data.shape,
+          atom_data_ex.shape, adj_data_ex.shape, is_real_node_ex.shape)
+    y_actual_ex = cuda.to_cpu(model(
+        atom_data_ex, adj_data_ex, is_real_node_ex).data)
+    assert numpy.allclose(y_actual, y_actual_ex, rtol=1e-5, atol=1e-6)
+
+
 if __name__ == '__main__':
-    pytest.main([__file__, '-v'])
+    pytest.main([__file__, '-v', '-s'])

--- a/tests/models_tests/test_nfp.py
+++ b/tests/models_tests/test_nfp.py
@@ -86,8 +86,7 @@ def test_forward_cpu_input_size_invariant(model, data):
     atom_data_ex = extend_node(atom_data, out_size=8)
     adj_data_ex = extend_adj(adj_data, out_size=8)
     is_real_node_ex = extend_node(is_real_node, out_size=8)
-    print('size', atom_data.shape, adj_data.shape,
-          atom_data_ex.shape, adj_data_ex.shape, is_real_node_ex.shape)
+
     y_actual_ex = cuda.to_cpu(model(
         atom_data_ex, adj_data_ex, is_real_node_ex).data)
     assert numpy.allclose(y_actual, y_actual_ex, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
take over from https://github.com/pfnet-research/chainer-chemistry/pull/228
when is_real_node passed, we can calculate the output value ignoring the effect from virtual node.