### PR TITLE
Add typing module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requires = [
     'scikit-learn',
     'scipy',
     'tqdm',
+    'typing'
 ]
 
 


### PR DESCRIPTION
This PR enables 'Type Hints' with python2.7.
You do not have to write 'Type Hints' for all scripts but it is better if you can.