### PR TITLE
Schnet add h

### DIFF
--- a/chainer_chemistry/dataset/preprocessors/schnet_preprocessor.py
+++ b/chainer_chemistry/dataset/preprocessors/schnet_preprocessor.py
@@ -36,10 +36,14 @@ def construct_distance_matrix(mol, out_size=-1):
         raise MolFeatureExtractionError('out_size {} is smaller than number '
                                         'of atoms in mol {}'
                                         .format(out_size, N))
+    ar1 = construct_atomic_number_array(mol)
     mol = AllChem.AddHs(mol)
     confid = AllChem.EmbedMolecule(mol)
     if mol.GetNumAtoms() != N:
         mol = AllChem.RemoveHs(mol)
+    ar2 = construct_atomic_number_array(mol)
+    assert((ar1 == ar2).all())
+
     
     try:
         dist_matrix = rdmolops.Get3DDistanceMatrix(mol, confId=confid)

--- a/chainer_chemistry/dataset/preprocessors/schnet_preprocessor.py
+++ b/chainer_chemistry/dataset/preprocessors/schnet_preprocessor.py
@@ -36,8 +36,11 @@ def construct_distance_matrix(mol, out_size=-1):
         raise MolFeatureExtractionError('out_size {} is smaller than number '
                                         'of atoms in mol {}'
                                         .format(out_size, N))
-
+    mol = AllChem.AddHs(mol)
     confid = AllChem.EmbedMolecule(mol)
+    if mol.GetNumAtoms() != N:
+        mol = AllChem.RemoveHs(mol)
+    
     try:
         dist_matrix = rdmolops.Get3DDistanceMatrix(mol, confId=confid)
     except ValueError as e:


### PR DESCRIPTION
Information of hydrogen atom is necessary to calculate three-dimensional distance accurately.
Therefore, we added a code to calculate the distance by adding hydrogen once, and a code to remove it again if the number of hydrogen increases.