### PR TITLE
fix typo MolVisualier, shape_transformer_2d

### DIFF
--- a/chainer_chemistry/links/scaler/max_abs_scaler.py
+++ b/chainer_chemistry/links/scaler/max_abs_scaler.py
@@ -4,7 +4,7 @@ import numpy
 from chainer import cuda, Variable
 
 from chainer_chemistry.links.scaler.base import BaseScaler, to_array  # NOQA
-from chainer_chemistry.links.array.shape_transformer_2d import ShapeTransformer2D  # NOQA
+from chainer_chemistry.links.array.shape_transformer_to_2d import ShapeTransformer2D  # NOQA
 
 
 def format_x(x):

--- a/chainer_chemistry/links/scaler/max_abs_scaler.py
+++ b/chainer_chemistry/links/scaler/max_abs_scaler.py
@@ -4,7 +4,7 @@ import numpy
 from chainer import cuda, Variable
 
 from chainer_chemistry.links.scaler.base import BaseScaler, to_array  # NOQA
-from chainer_chemistry.links.array.shape_transformer_to_2d import ShapeTransformer2D  # NOQA
+from chainer_chemistry.links.array.shape_transformer_to_2d import ShapeTransformerTo2D  # NOQA
 
 
 def format_x(x):

--- a/chainer_chemistry/links/scaler/max_abs_scaler.py
+++ b/chainer_chemistry/links/scaler/max_abs_scaler.py
@@ -39,7 +39,7 @@ class MaxAbsScaler(BaseScaler):
         """
         x = to_array(x)
         x = format_x(x)
-        x = ShapeTransformer2D(axis=axis).transform(x).array
+        x = ShapeTransformerTo2D(axis=axis).transform(x).array
 
         if indices is None:
             pass

--- a/chainer_chemistry/links/scaler/max_abs_scaler.py
+++ b/chainer_chemistry/links/scaler/max_abs_scaler.py
@@ -80,7 +80,7 @@ class MaxAbsScaler(BaseScaler):
             raise AttributeError(
                 '[Error] max_abs is None, call fit beforehand!')
         x = format_x(x)
-        shape_transformer = ShapeTransformer2D(axis=axis)
+        shape_transformer = ShapeTransformerTo2D(axis=axis)
         x = shape_transformer.transform(x)
         max_abs_all = self._compute_max_abs_all(x.shape[1])
         x = x / max_abs_all[None, :]
@@ -95,7 +95,7 @@ class MaxAbsScaler(BaseScaler):
             raise AttributeError(
                 '[Error] max_abs is None, call fit beforehand!')
         x = format_x(x)
-        shape_transformer = ShapeTransformer2D(axis=axis)
+        shape_transformer = ShapeTransformerTo2D(axis=axis)
         x = shape_transformer.transform(x)
         max_abs_all = self._compute_max_abs_all(x.shape[1])
         x = x * max_abs_all[None, :]

--- a/chainer_chemistry/links/scaler/min_max_scaler.py
+++ b/chainer_chemistry/links/scaler/min_max_scaler.py
@@ -4,7 +4,7 @@ import numpy
 from chainer import cuda, Variable
 
 from chainer_chemistry.links.scaler.base import BaseScaler, to_array  # NOQA
-from chainer_chemistry.links.array.shape_transformer_2d import ShapeTransformer2D  # NOQA
+from chainer_chemistry.links.array.shape_transformer_to_2d import ShapeTransformer2D  # NOQA
 
 
 def format_x(x):

--- a/chainer_chemistry/links/scaler/min_max_scaler.py
+++ b/chainer_chemistry/links/scaler/min_max_scaler.py
@@ -41,7 +41,7 @@ class MinMaxScaler(BaseScaler):
         """
         x = to_array(x)
         x = format_x(x)
-        x = ShapeTransformer2D(axis=axis).transform(x).array
+        x = ShapeTransformerTo2D(axis=axis).transform(x).array
 
         if indices is None:
             pass
@@ -87,7 +87,7 @@ class MinMaxScaler(BaseScaler):
             raise AttributeError(
                 '[Error] min is None, call fit beforehand!')
         x = format_x(x)
-        shape_transformer = ShapeTransformer2D(axis=axis)
+        shape_transformer = ShapeTransformerTo2D(axis=axis)
         x = shape_transformer.transform(x)
         min_all, diff_all = self._compute_min_diff_all(x.shape[1])
         x = (x - min_all[None, :]) / diff_all[None, :]
@@ -102,7 +102,7 @@ class MinMaxScaler(BaseScaler):
             raise AttributeError(
                 '[Error] min is None, call fit beforehand!')
         x = format_x(x)
-        shape_transformer = ShapeTransformer2D(axis=axis)
+        shape_transformer = ShapeTransformerTo2D(axis=axis)
         x = shape_transformer.transform(x)
 
         min_all, diff_all = self._compute_min_diff_all(x.shape[1])

--- a/chainer_chemistry/links/scaler/min_max_scaler.py
+++ b/chainer_chemistry/links/scaler/min_max_scaler.py
@@ -4,7 +4,7 @@ import numpy
 from chainer import cuda, Variable
 
 from chainer_chemistry.links.scaler.base import BaseScaler, to_array  # NOQA
-from chainer_chemistry.links.array.shape_transformer_to_2d import ShapeTransformer2D  # NOQA
+from chainer_chemistry.links.array.shape_transformer_to_2d import ShapeTransformerTo2D  # NOQA
 
 
 def format_x(x):

--- a/chainer_chemistry/saliency/visualizer/__init__.py
+++ b/chainer_chemistry/saliency/visualizer/__init__.py
@@ -6,7 +6,7 @@ from chainer_chemistry.saliency.visualizer import table_visualizer  # NOQA
 
 from chainer_chemistry.saliency.visualizer.base_visualizer import BaseVisualizer  # NOQA
 from chainer_chemistry.saliency.visualizer.image_visualizer import ImageVisualizer  # NOQA
-from chainer_chemistry.saliency.visualizer.mol_visualizer import MolVisualier  # NOQA
+from chainer_chemistry.saliency.visualizer.mol_visualizer import MolVisualizer  # NOQA
 from chainer_chemistry.saliency.visualizer.mol_visualizer import SmilesVisualizer  # NOQA
 from chainer_chemistry.saliency.visualizer.table_visualizer import TableVisualizer  # NOQA
 

--- a/chainer_chemistry/saliency/visualizer/mol_visualizer.py
+++ b/chainer_chemistry/saliency/visualizer/mol_visualizer.py
@@ -33,7 +33,7 @@ def is_visible(begin, end):
         return (begin + end) * 0.5
 
 
-class MolVisualier(BaseVisualizer):
+class MolVisualizer(BaseVisualizer):
 
     """Saliency visualizer for mol data
 
@@ -136,7 +136,7 @@ class MolVisualier(BaseVisualizer):
                 return None
 
 
-class SmilesVisualizer(MolVisualier):
+class SmilesVisualizer(MolVisualizer):
 
     def visualize(self, saliency, smiles, save_filepath=None,
                   visualize_ratio=1.0, color_fn=red_blue_cmap,

--- a/tests/saliency_tests/visualizer_tests/test_mol_visualizer.py
+++ b/tests/saliency_tests/visualizer_tests/test_mol_visualizer.py
@@ -4,7 +4,7 @@ import numpy
 import pytest
 from rdkit import Chem
 
-from chainer_chemistry.saliency.visualizer.mol_visualizer import MolVisualier  # NOQA
+from chainer_chemistry.saliency.visualizer.mol_visualizer import MolVisualizer  # NOQA
 from chainer_chemistry.saliency.visualizer.mol_visualizer import SmilesVisualizer  # NOQA
 
 
@@ -13,7 +13,7 @@ def test_mol_visualizer(tmpdir):
     smiles = 'OCO'
     mol = Chem.MolFromSmiles(smiles)
     saliency = numpy.array([0.5, 0.3, 0.2])
-    visualizer = MolVisualier()
+    visualizer = MolVisualizer()
 
     # 1. test with setting save_filepath
     save_filepath = os.path.join(str(tmpdir), 'tmp.svg')
@@ -50,7 +50,7 @@ def test_smiles_visualizer(tmpdir):
 
 
 def test_mol_visualizer_assert_raises(tmpdir):
-    visualizer = MolVisualier()
+    visualizer = MolVisualizer()
     smiles = 'OCO'
     mol = Chem.MolFromSmiles(smiles)
 


### PR DESCRIPTION
I'm sorry I did not check my folk is latest or not.

This is some fix typo.
MolVisualier -> MolVisualizer
shape_transformer_2d ->shape_transformer_to_2d
ShapeTransformer2D -> ShapeTransformerTo2D