### PR TITLE
allow_pickle=True

### DIFF
--- a/chainer_chemistry/datasets/numpy_tuple_dataset.py
+++ b/chainer_chemistry/datasets/numpy_tuple_dataset.py
@@ -86,10 +86,10 @@ class NumpyTupleDataset(object):
         numpy.savez(filepath, *numpy_tuple_dataset._datasets)
 
     @classmethod
-    def load(cls, filepath):
+    def load(cls, filepath, allow_pickle=True):
         if not os.path.exists(filepath):
             return None
-        load_data = numpy.load(filepath)
+        load_data = numpy.load(filepath, allow_pickle=allow_pickle)
         result = []
         i = 0
         while True:


### PR DESCRIPTION
numpy changed its default value from version 1.16.2, we need to explicitly set `allow_pickle=True` to load object type.