### PR TITLE
add shifted softplus

### DIFF
--- a/chainer_chemistry/functions/__init__.py
+++ b/chainer_chemistry/functions/__init__.py
@@ -1,4 +1,5 @@
 from chainer_chemistry.functions.activation.softmax import softmax  # NOQA
+from chainer_chemistry.functions.activation.shifted_softplus import shifted_softplus  # NOQA
 
 from chainer_chemistry.functions.evaluation.r2_score import r2_score  # NOQA
 from chainer_chemistry.functions.evaluation.r2_score import R2Score  # NOQA

--- a/chainer_chemistry/functions/activation/shifted_softplus.py
+++ b/chainer_chemistry/functions/activation/shifted_softplus.py
@@ -1,0 +1,15 @@
+import chainer
+from chainer import functions
+
+
+def shifted_softplus(x, beta=0.5):
+    """shifted softplus function, which holds f(0)=0.
+
+     Args:
+        x (Variable): Input variable
+
+    Returns:
+        output (Variable): Output variable whose shape is same with `x`
+    """
+    xp = chainer.cuda.get_array_module(x)
+    return functions.softplus(x) + xp.log(beta)

--- a/chainer_chemistry/functions/activation/shifted_softplus.py
+++ b/chainer_chemistry/functions/activation/shifted_softplus.py
@@ -2,7 +2,7 @@ import chainer
 from chainer import functions
 
 
-def shifted_softplus(x, shift=0.5):
+def shifted_softplus(x, beta=1, shift=0.5):
     """shifted softplus function, which holds f(0)=0.
 
      Args:
@@ -12,4 +12,4 @@ def shifted_softplus(x, shift=0.5):
         output (Variable): Output variable whose shape is same with `x`
     """
     xp = chainer.cuda.get_array_module(x)
-    return functions.softplus(x) + xp.log(shift)
+    return functions.softplus(x, beta=beta) + xp.log(shift)

--- a/chainer_chemistry/functions/activation/shifted_softplus.py
+++ b/chainer_chemistry/functions/activation/shifted_softplus.py
@@ -15,6 +15,7 @@ def shifted_softplus(x, beta=1, shift=0.5, threshold=20):
         output (Variable): Output variable whose shape is same with `x`
     """
     xp = chainer.cuda.get_array_module(x)
-    x = functions.where(x > threshold, x, functions.softplus(x, beta=beta))
+    x = functions.where(x.array > threshold, x,
+                        functions.softplus(x, beta=beta))
     x += xp.log(shift)
     return x

--- a/chainer_chemistry/functions/activation/shifted_softplus.py
+++ b/chainer_chemistry/functions/activation/shifted_softplus.py
@@ -15,7 +15,11 @@ def shifted_softplus(x, beta=1, shift=0.5, threshold=20):
         output (Variable): Output variable whose shape is same with `x`
     """
     xp = chainer.cuda.get_array_module(x)
-    x = functions.where(x.array > threshold, x,
+    if isinstance(x, chainer.Variable):
+        cond = x.array > 20
+    else:
+        cond = x > 20
+    x = functions.where(cond, x,
                         functions.softplus(x, beta=beta))
     x += xp.log(shift)
     return x

--- a/chainer_chemistry/functions/activation/shifted_softplus.py
+++ b/chainer_chemistry/functions/activation/shifted_softplus.py
@@ -16,9 +16,9 @@ def shifted_softplus(x, beta=1, shift=0.5, threshold=20):
     """
     xp = chainer.cuda.get_array_module(x)
     if isinstance(x, chainer.Variable):
-        cond = x.array > 20
+        cond = x.array > threshold
     else:
-        cond = x > 20
+        cond = x > threshold
     x = functions.where(cond, x,
                         functions.softplus(x, beta=beta))
     x += xp.log(shift)

--- a/chainer_chemistry/functions/activation/shifted_softplus.py
+++ b/chainer_chemistry/functions/activation/shifted_softplus.py
@@ -2,14 +2,19 @@ import chainer
 from chainer import functions
 
 
-def shifted_softplus(x, beta=1, shift=0.5):
+def shifted_softplus(x, beta=1, shift=0.5, threshold=20):
     """shifted softplus function, which holds f(0)=0.
 
      Args:
         x (Variable): Input variable
+        beta (float): Parameter :math:`\\beta`.
+        shift (float): Shift Parameter 
+        threshold (float): threshold to avoid overflow
 
     Returns:
         output (Variable): Output variable whose shape is same with `x`
     """
     xp = chainer.cuda.get_array_module(x)
-    return functions.softplus(x, beta=beta) + xp.log(shift)
+    x = functions.where(x > threshold, x, functions.softplus(x, beta=beta))
+    x += xp.log(shift)
+    return x

--- a/chainer_chemistry/functions/activation/shifted_softplus.py
+++ b/chainer_chemistry/functions/activation/shifted_softplus.py
@@ -2,7 +2,7 @@ import chainer
 from chainer import functions
 
 
-def shifted_softplus(x, beta=0.5):
+def shifted_softplus(x, shift=0.5):
     """shifted softplus function, which holds f(0)=0.
 
      Args:
@@ -12,4 +12,4 @@ def shifted_softplus(x, beta=0.5):
         output (Variable): Output variable whose shape is same with `x`
     """
     xp = chainer.cuda.get_array_module(x)
-    return functions.softplus(x) + xp.log(beta)
+    return functions.softplus(x) + xp.log(shift)

--- a/chainer_chemistry/links/readout/schnet_readout.py
+++ b/chainer_chemistry/links/readout/schnet_readout.py
@@ -2,6 +2,7 @@ import chainer
 from chainer import functions
 
 from chainer_chemistry.links.connection.graph_linear import GraphLinear
+from chainer_chemistry.functions import shifted_softplus
 
 
 class SchNetReadout(chainer.Chain):
@@ -24,7 +25,7 @@ class SchNetReadout(chainer.Chain):
 
     def __call__(self, h, **kwargs):
         h = self.linear1(h)
-        h = functions.softplus(h)
+        h = shifted_softplus(h)
         h = self.linear2(h)
         h = functions.sum(h, axis=1)
         return h

--- a/chainer_chemistry/links/update/schnet_update.py
+++ b/chainer_chemistry/links/update/schnet_update.py
@@ -11,7 +11,9 @@ import chainer
 from chainer import functions
 from chainer import links
 
+
 from chainer_chemistry.links.connection.graph_linear import GraphLinear
+from chainer_chemistry.functions import shifted_softplus
 
 
 class CFConv(chainer.Chain):
@@ -57,9 +59,9 @@ class CFConv(chainer.Chain):
         dist = functions.exp(- self.gamma * (dist - embedlist) ** 2)
         dist = functions.reshape(dist, (-1, self.num_rbf))
         dist = self.dense1(dist)
-        dist = functions.softplus(dist)
+        dist = shifted_softplus(dist)
         dist = self.dense2(dist)
-        dist = functions.softplus(dist)
+        dist = shifted_softplus(dist)
         dist = functions.reshape(dist, (mb, atom, atom, self.hidden_dim))
         h = functions.reshape(h, (mb, atom, 1, self.hidden_dim))
         h = functions.broadcast_to(h, (mb, atom, atom, self.hidden_dim))
@@ -95,6 +97,6 @@ class SchNetUpdate(chainer.Chain):
         v = self.linear[0](h)
         v = self.cfconv(v, adj)
         v = self.linear[1](v)
-        v = functions.softplus(v)
+        v = shifted_softplus(v)
         v = self.linear[2](v)
         return h + v

--- a/result/log
+++ b/result/log
@@ -1,0 +1,9 @@
+[
+    {
+        "main/loss": 0.34406228363513947,
+        "validation/main/loss": 0.3792259097099304,
+        "epoch": 1,
+        "iteration": 2,
+        "elapsed_time": 0.010565152391791344
+    }
+]

--- a/result/log
+++ b/result/log
@@ -1,9 +1,0 @@
-[
-    {
-        "main/loss": 0.34406228363513947,
-        "validation/main/loss": 0.3792259097099304,
-        "epoch": 1,
-        "iteration": 2,
-        "elapsed_time": 0.010565152391791344
-    }
-]

--- a/tests/functions_tests/activation/test_shifted_softplus.py
+++ b/tests/functions_tests/activation/test_shifted_softplus.py
@@ -25,6 +25,13 @@ def test_forward_zero_cpu():
     numpy.allclose(output.array, expect_output)
 
 
+def test_forward_avoid_overflow_cpu():
+    x = numpy.array([1e5], dtype=numpy.float32)
+    output = shifted_softplus(x)
+    expect_output = numpy.array([1e5], dtype=numpy.float32)
+    numpy.allclose(output.array, expect_output)
+
+
 @pytest.mark.gpu
 def test_forward_gpu():
     x = cuda.to_gpu(numpy.array([[1, 2, 3], [6, 5, 4]], dtype=numpy.float32))
@@ -40,6 +47,14 @@ def test_forward_zero_gpu():
     x = cuda.to_gpu(numpy.zeros((2, 3), dtype=numpy.float32))
     output = shifted_softplus(x)
     expect_output = numpy.zeros((2, 3), dtype=numpy.float32)
+    numpy.allclose(cuda.to_cpu(output.array), expect_output)
+
+
+@pytest.mark.gpu
+def test_forward_avoid_overflow_gpu():
+    x = cuda.to_gpu(numpy.array([1e5], dtype=numpy.float32))
+    output = shifted_softplus(x)
+    expect_output = numpy.array([1e5], dtype=numpy.float32)
     numpy.allclose(cuda.to_cpu(output.array), expect_output)
 
 

--- a/tests/functions_tests/activation/test_shifted_softplus.py
+++ b/tests/functions_tests/activation/test_shifted_softplus.py
@@ -18,6 +18,13 @@ def test_forward_cpu():
     numpy.allclose(output.array, expect_output)
 
 
+def test_forward_zero_cpu():
+    x = numpy.zeros((2, 3), dtype=numpy.float32)
+    output = shifted_softplus(x)
+    expect_output = numpy.zeros((2, 3), dtype=numpy.float32)
+    numpy.allclose(output.array, expect_output)
+
+
 @pytest.mark.gpu
 def test_forward_gpu():
     x = cuda.to_gpu(numpy.array([[1, 2, 3], [6, 5, 4]], dtype=numpy.float32))
@@ -25,6 +32,14 @@ def test_forward_gpu():
     expect_output = numpy.array([
         [0.62011445, 1.4337809, 2.3554401],
         [5.3093286, 4.313568, 3.3250027]], dtype=numpy.float32)
+    numpy.allclose(cuda.to_cpu(output.array), expect_output)
+
+
+@pytest.mark.gpu
+def test_forward_zero_gpu():
+    x = cuda.to_gpu(numpy.zeros((2, 3), dtype=numpy.float32))
+    output = shifted_softplus(x)
+    expect_output = numpy.zeros((2, 3), dtype=numpy.float32)
     numpy.allclose(cuda.to_cpu(output.array), expect_output)
 
 

--- a/tests/functions_tests/activation/test_shifted_softplus.py
+++ b/tests/functions_tests/activation/test_shifted_softplus.py
@@ -1,0 +1,32 @@
+import numpy
+import pytest
+
+import chainer
+from chainer import cuda
+from chainer import gradient_check
+
+import chainer_chemistry
+from chainer_chemistry.functions.activation.shifted_softplus import shifted_softplus
+
+
+def test_forward_cpu():
+    x = numpy.array([[1, 2, 3], [6, 5, 4]], dtype=numpy.float32)
+    output = shifted_softplus(x)
+    expect_output = numpy.array([
+        [0.62011445, 1.4337809, 2.3554401],
+        [5.3093286, 4.313568, 3.3250027]], dtype=numpy.float32)
+    numpy.allclose(output.array, expect_output)
+
+
+@pytest.mark.gpu
+def test_forward_gpu():
+    x = cuda.to_gpu(numpy.array([[1, 2, 3], [6, 5, 4]], dtype=numpy.float32))
+    output = shifted_softplus(x)
+    expect_output = numpy.array([
+        [0.62011445, 1.4337809, 2.3554401],
+        [5.3093286, 4.313568, 3.3250027]], dtype=numpy.float32)
+    numpy.allclose(cuda.to_cpu(output.array), expect_output)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v', '-s'])


### PR DESCRIPTION
Add shifted-softplus for SchNet for stability
Add test of shifted softplus

## qm9 examples 

before

```
epoch       main/loss   main/mae    main/rmse   validation/main/loss  validation/main/mae  validation/main/rmse  elapsed_time
1           9.16072e+07  4635.03     5493.88     2.04751e+06           1172.89              1430.77               4.68606       
2           736497      626.273     809.699     175424                307.404              418.077               8.61846       
3           111058      246.223     331.111     83034.3               203.431              286.713               12.6977       
...
20          8439.32     56.8124     90.6312     9510.97               55.5326              92.7485               81.2714       
```

after
```
epoch       main/loss   main/mae    main/rmse   validation/main/loss  validation/main/mae  validation/main/rmse  elapsed_time
1           1665.32     28.0805     33.3155     163.623               7.94275              12.7757               4.86237       
2           106.288     4.85469     10.128      69.1701               3.48232              8.2747                9.02798       
3           59.911      2.95717     7.69376     41.7183               2.6097               6.42595               13.3118       
...
20          0.719011    0.659139    0.847248    0.741667              0.641484             0.85456               86.3188     
```
