### PR TITLE
Use as_variable instead of isinstance

### DIFF
--- a/chainer_chemistry/functions/activation/shifted_softplus.py
+++ b/chainer_chemistry/functions/activation/shifted_softplus.py
@@ -15,10 +15,7 @@ def shifted_softplus(x, beta=1, shift=0.5, threshold=20):
         output (Variable): Output variable whose shape is same with `x`
     """
     xp = chainer.cuda.get_array_module(x)
-    if isinstance(x, chainer.Variable):
-        cond = x.array > threshold
-    else:
-        cond = x > threshold
+    cond = chainer.as_variable(x).array > threshold
     x = functions.where(cond, x,
                         functions.softplus(x, beta=beta))
     x += xp.log(shift)


### PR DESCRIPTION
I think `chainer.as_variable` is better choice here because it throws a descriptive error if `x` cannot be treated as an array.